### PR TITLE
Moving dependency version declarations to maven properties

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-<!--      <version>2.13.16</version>-->
+      <version>2.13.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-json/pom.xml
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.16</version>
+<!--      <version>2.13.16</version>-->
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,24 @@
     <ivy.version>2.5.3</ivy.version>
     <c3p0.version>0.11.0-pre2</c3p0.version>
     <mchange-commons-java.version>0.3.2</mchange-commons-java.version>
+    <checker-qual.version>3.49.1</checker-qual.version>
+    <groovy-all.version>2.4.21</groovy-all.version>
+    <xml-apis.version>2.0.2</xml-apis.version>
+    <RoaringBitmap.version>1.3.0</RoaringBitmap.version>
+    <jmx_prometheus_javaagent.version>0.19.0</jmx_prometheus_javaagent.version>
+    <fastutil.version>8.5.15</fastutil.version>
+    <disruptor.version>4.0.0</disruptor.version>
+    <snakeyaml.version>2.4</snakeyaml.version>
+    <hadoop-shaded-protobuf_3_25.version>1.3.0</hadoop-shaded-protobuf_3_25.version>
+    <stream.version>2.9.8</stream.version>
+    <datasketches-java.version>6.2.0</datasketches-java.version>
+    <t-digest.version>3.2</t-digest.version>
+    <picocli.version>4.7.6</picocli.version>
+    <tyrus-standalone-client.version>2.2.0</tyrus-standalone-client.version>
+    <jopt-simple.version>5.0.4</jopt-simple.version>
+    <ipaddress.version>5.5.1</ipaddress.version>
+    <posix.version>2.27ea1</posix.version>
+    <chronicle-core.version>2.27ea2</chronicle-core.version>
 
     <!-- Test Libraries -->
     <testng.version>7.11.0</testng.version>
@@ -792,22 +810,26 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.49.1</version>
+        <version>${checker-qual.version}</version>
+<!--        <version>3.49.1</version>-->
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.4.21</version>
+        <version>${groovy-all.version}</version>
+<!--        <version>2.4.21</version>-->
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
-        <version>2.0.2</version>
+        <version>${xml-apis.version}</version>
+<!--        <version>2.0.2</version>-->
       </dependency>
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>1.3.0</version>
+        <version>${RoaringBitmap.version}</version>
+<!--        <version>1.3.0</version>-->
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>
@@ -829,7 +851,8 @@
       <dependency>
         <groupId>io.prometheus.jmx</groupId>
         <artifactId>jmx_prometheus_javaagent</artifactId>
-        <version>0.19.0</version>
+        <version>${jmx_prometheus_javaagent.version}</version>
+<!--        <version>0.19.0</version>-->
         <scope>test</scope>
       </dependency>
 
@@ -855,7 +878,8 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.5.15</version>
+        <version>${fastutil.version}</version>
+<!--        <version>8.5.15</version>-->
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>
@@ -983,7 +1007,8 @@
       <dependency>
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
-        <version>4.0.0</version>
+        <version>${disruptor.version}</version>
+<!--        <version>4.0.0</version>-->
       </dependency>
 
       <dependency>
@@ -994,7 +1019,8 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>2.4</version>
+        <version>${snakeyaml.version}</version>
+<!--        <version>2.4</version>-->
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
@@ -1376,7 +1402,8 @@
       <dependency>
         <groupId>org.apache.hadoop.thirdparty</groupId>
         <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
-        <version>1.3.0</version>
+        <version>${hadoop-shaded-protobuf_3_25.version}</version>
+<!--        <version>1.3.0</version>-->
       </dependency>
 
       <!-- Metrics -->
@@ -1414,12 +1441,14 @@
       <dependency>
         <groupId>com.clearspring.analytics</groupId>
         <artifactId>stream</artifactId>
-        <version>2.9.8</version>
+        <version>${stream.version}</version>
+<!--        <version>2.9.8</version>-->
       </dependency>
       <dependency>
         <groupId>org.apache.datasketches</groupId>
         <artifactId>datasketches-java</artifactId>
-        <version>6.2.0</version>
+        <version>${datasketches-java.version}</version>
+<!--        <version>6.2.0</version>-->
       </dependency>
       <dependency>
         <groupId>com.dynatrace.hash4j</groupId>
@@ -1429,7 +1458,8 @@
       <dependency>
         <groupId>com.tdunning</groupId>
         <artifactId>t-digest</artifactId>
-        <version>3.2</version>
+        <version>${t-digest.version}</version>
+<!--        <version>3.2</version>-->
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
@@ -1559,17 +1589,20 @@
       <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
-        <version>4.7.6</version>
+        <version>${picocli.version}</version>
+<!--        <version>4.7.6</version>-->
       </dependency>
       <dependency>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-standalone-client</artifactId>
-        <version>2.2.0</version>
+        <version>${tyrus-standalone-client.version}</version>
+<!--        <version>2.2.0</version>-->
       </dependency>
       <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>
-        <version>5.0.4</version>
+        <version>${jopt-simple.version}</version>
+<!--        <version>5.0.4</version>-->
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
@@ -1590,18 +1623,21 @@
       <dependency>
         <groupId>com.github.seancfoley</groupId>
         <artifactId>ipaddress</artifactId>
-        <version>5.5.1</version>
+        <version>${ipaddress.version}</version>
+<!--        <version>5.5.1</version>-->
       </dependency>
 
       <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>posix</artifactId>
-        <version>2.27ea1</version>
+        <version>${posix.version}</version>
+<!--        <version>2.27ea1</version>-->
       </dependency>
       <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>chronicle-core</artifactId>
-        <version>2.27ea2</version>
+        <version>${chronicle-core.version}</version>
+<!--        <version>2.27ea2</version>-->
       </dependency>
 
       <dependency>
@@ -2070,6 +2106,7 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
+<!--          <version>${spotless-maven-plugin.version}</version>-->
           <version>2.44.3</version>
           <executions>
             <execution>
@@ -2094,6 +2131,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>appassembler-maven-plugin</artifactId>
+<!--          <version>${appassembler-maven-plugin.version}</version>-->
           <version>2.1.0</version>
           <configuration>
             <binFileExtensions>
@@ -2137,6 +2175,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
+<!--          <version>${jacoco-maven-plugin.version}</version>-->
           <version>0.8.12</version>
         </plugin>
         <plugin>
@@ -2250,16 +2289,19 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
+<!--          <version>${license-maven-plugin.version}</version>-->
           <version>5.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
+<!--          <version>${buildnumber-maven-plugin.version}</version>-->
           <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
+<!--          <version>${versions-maven-plugin.version}</version>-->
           <version>2.18.0</version>
         </plugin>
         <plugin>
@@ -2269,6 +2311,7 @@
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
+<!--              <version>${maven-scm-provider-gitexe.version}</version>-->
               <version>2.1.0</version>
             </dependency>
           </dependencies>
@@ -2279,6 +2322,7 @@
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
+<!--          <version>${protobuf-maven-plugin.version}</version>-->
           <version>0.6.1</version>
           <configuration>
             <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
@@ -2330,12 +2374,14 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>javacc-maven-plugin</artifactId>
+<!--          <version>${javacc-maven-plugin.version}</version>-->
           <version>3.1.0</version>
           <dependencies>
             <dependency>
               <groupId>net.java.dev.javacc</groupId>
               <artifactId>javacc</artifactId>
               <!-- Higher version JavaCC throws exception when generating custom Calcite parser -->
+<!--              <version>${javacc.version}</version>-->
               <version>5.0</version>
             </dependency>
           </dependencies>
@@ -2343,6 +2389,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
+<!--          <version>${scala-maven-plugin.version}</version>-->
           <version>4.9.2</version>
           <executions>
             <execution>
@@ -2399,6 +2446,7 @@
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
+<!--          <version>${scalatest-maven-plugin.version}</version>-->
           <version>2.2.0</version>
           <configuration>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
@@ -2417,16 +2465,19 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
+<!--          <version>${frontend-maven-plugin.version}</version>-->
           <version>1.15.1</version>
         </plugin>
         <plugin>
           <groupId>net.nicoulaj.maven.plugins</groupId>
           <artifactId>checksum-maven-plugin</artifactId>
+<!--          <version>${checksum-maven-plugin.version}</version>-->
           <version>1.11</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
+<!--          <version>${exec-maven-plugin.version}</version>-->
           <version>3.5.0</version>
         </plugin>
       </plugins>
@@ -2449,6 +2500,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
+<!--            <version>${checkstyle.version}</version>-->
             <version>10.21.4</version>
           </dependency>
         </dependencies>
@@ -2765,6 +2817,7 @@
           <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+<!--            <version>${log4j-transform-maven-shade-plugin-extensions.version}</version>-->
             <version>0.2.0</version>
           </dependency>
         </dependencies>
@@ -2839,6 +2892,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
+<!--        <version>${maven-jxr-plugin.version}</version>-->
         <version>3.6.0</version>
         <configuration>
           <aggregate>true</aggregate>

--- a/pom.xml
+++ b/pom.xml
@@ -811,25 +811,21 @@
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${checker-qual.version}</version>
-<!--        <version>3.49.1</version>-->
       </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
         <version>${groovy-all.version}</version>
-<!--        <version>2.4.21</version>-->
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
         <version>${xml-apis.version}</version>
-<!--        <version>2.0.2</version>-->
       </dependency>
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
         <version>${RoaringBitmap.version}</version>
-<!--        <version>1.3.0</version>-->
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>
@@ -852,7 +848,6 @@
         <groupId>io.prometheus.jmx</groupId>
         <artifactId>jmx_prometheus_javaagent</artifactId>
         <version>${jmx_prometheus_javaagent.version}</version>
-<!--        <version>0.19.0</version>-->
         <scope>test</scope>
       </dependency>
 
@@ -879,7 +874,6 @@
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
         <version>${fastutil.version}</version>
-<!--        <version>8.5.15</version>-->
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>
@@ -1008,7 +1002,6 @@
         <groupId>com.lmax</groupId>
         <artifactId>disruptor</artifactId>
         <version>${disruptor.version}</version>
-<!--        <version>4.0.0</version>-->
       </dependency>
 
       <dependency>
@@ -1020,7 +1013,6 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
-<!--        <version>2.4</version>-->
       </dependency>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
@@ -1403,7 +1395,6 @@
         <groupId>org.apache.hadoop.thirdparty</groupId>
         <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
         <version>${hadoop-shaded-protobuf_3_25.version}</version>
-<!--        <version>1.3.0</version>-->
       </dependency>
 
       <!-- Metrics -->
@@ -1442,13 +1433,11 @@
         <groupId>com.clearspring.analytics</groupId>
         <artifactId>stream</artifactId>
         <version>${stream.version}</version>
-<!--        <version>2.9.8</version>-->
       </dependency>
       <dependency>
         <groupId>org.apache.datasketches</groupId>
         <artifactId>datasketches-java</artifactId>
         <version>${datasketches-java.version}</version>
-<!--        <version>6.2.0</version>-->
       </dependency>
       <dependency>
         <groupId>com.dynatrace.hash4j</groupId>
@@ -1459,7 +1448,6 @@
         <groupId>com.tdunning</groupId>
         <artifactId>t-digest</artifactId>
         <version>${t-digest.version}</version>
-<!--        <version>3.2</version>-->
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
@@ -1590,19 +1578,16 @@
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>${picocli.version}</version>
-<!--        <version>4.7.6</version>-->
       </dependency>
       <dependency>
         <groupId>org.glassfish.tyrus.bundles</groupId>
         <artifactId>tyrus-standalone-client</artifactId>
         <version>${tyrus-standalone-client.version}</version>
-<!--        <version>2.2.0</version>-->
       </dependency>
       <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>
         <version>${jopt-simple.version}</version>
-<!--        <version>5.0.4</version>-->
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>
@@ -1624,20 +1609,17 @@
         <groupId>com.github.seancfoley</groupId>
         <artifactId>ipaddress</artifactId>
         <version>${ipaddress.version}</version>
-<!--        <version>5.5.1</version>-->
       </dependency>
 
       <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>posix</artifactId>
         <version>${posix.version}</version>
-<!--        <version>2.27ea1</version>-->
       </dependency>
       <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>chronicle-core</artifactId>
         <version>${chronicle-core.version}</version>
-<!--        <version>2.27ea2</version>-->
       </dependency>
 
       <dependency>
@@ -2106,7 +2088,6 @@
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-<!--          <version>${spotless-maven-plugin.version}</version>-->
           <version>2.44.3</version>
           <executions>
             <execution>
@@ -2131,7 +2112,6 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>appassembler-maven-plugin</artifactId>
-<!--          <version>${appassembler-maven-plugin.version}</version>-->
           <version>2.1.0</version>
           <configuration>
             <binFileExtensions>
@@ -2175,7 +2155,6 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-<!--          <version>${jacoco-maven-plugin.version}</version>-->
           <version>0.8.12</version>
         </plugin>
         <plugin>
@@ -2289,19 +2268,16 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-<!--          <version>${license-maven-plugin.version}</version>-->
           <version>5.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-<!--          <version>${buildnumber-maven-plugin.version}</version>-->
           <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-<!--          <version>${versions-maven-plugin.version}</version>-->
           <version>2.18.0</version>
         </plugin>
         <plugin>
@@ -2311,7 +2287,6 @@
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
-<!--              <version>${maven-scm-provider-gitexe.version}</version>-->
               <version>2.1.0</version>
             </dependency>
           </dependencies>
@@ -2322,7 +2297,6 @@
         <plugin>
           <groupId>org.xolstice.maven.plugins</groupId>
           <artifactId>protobuf-maven-plugin</artifactId>
-<!--          <version>${protobuf-maven-plugin.version}</version>-->
           <version>0.6.1</version>
           <configuration>
             <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
@@ -2374,14 +2348,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>javacc-maven-plugin</artifactId>
-<!--          <version>${javacc-maven-plugin.version}</version>-->
           <version>3.1.0</version>
           <dependencies>
             <dependency>
               <groupId>net.java.dev.javacc</groupId>
               <artifactId>javacc</artifactId>
               <!-- Higher version JavaCC throws exception when generating custom Calcite parser -->
-<!--              <version>${javacc.version}</version>-->
               <version>5.0</version>
             </dependency>
           </dependencies>
@@ -2389,7 +2361,6 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-<!--          <version>${scala-maven-plugin.version}</version>-->
           <version>4.9.2</version>
           <executions>
             <execution>
@@ -2446,7 +2417,6 @@
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-<!--          <version>${scalatest-maven-plugin.version}</version>-->
           <version>2.2.0</version>
           <configuration>
             <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
@@ -2465,19 +2435,16 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-<!--          <version>${frontend-maven-plugin.version}</version>-->
           <version>1.15.1</version>
         </plugin>
         <plugin>
           <groupId>net.nicoulaj.maven.plugins</groupId>
           <artifactId>checksum-maven-plugin</artifactId>
-<!--          <version>${checksum-maven-plugin.version}</version>-->
           <version>1.11</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-<!--          <version>${exec-maven-plugin.version}</version>-->
           <version>3.5.0</version>
         </plugin>
       </plugins>
@@ -2500,7 +2467,6 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-<!--            <version>${checkstyle.version}</version>-->
             <version>10.21.4</version>
           </dependency>
         </dependencies>
@@ -2817,7 +2783,6 @@
           <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
-<!--            <version>${log4j-transform-maven-shade-plugin-extensions.version}</version>-->
             <version>0.2.0</version>
           </dependency>
         </dependencies>
@@ -2892,7 +2857,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-<!--        <version>${maven-jxr-plugin.version}</version>-->
         <version>3.6.0</version>
         <configuration>
           <aggregate>true</aggregate>


### PR DESCRIPTION
I have started the work on the proposal outlined in the issue [#12676](https://github.com/apache/pinot/issues/12676).
As a first step, I have start by moving dependency version declarations to `<properties>` in the main POM as mentioned in issue [#12735](https://github.com/apache/pinot/issues/12735).
This creates a more consistent approach to dependency management as outlined in the original proposal and also in the doc [Dependency Management Guidelines](https://docs.pinot.apache.org/developers/developers-and-contributors/dependency-management).
The first attemp at this was done as part of issue [#12376](https://github.com/apache/pinot/pull/12736).
I have resume this work.

cc @siddharthteotia

Affected dependencies:
- checker-qual
- groovy-all
- xml-apis
- RoaringBitmap
- jmx_prometheus_javaagent
- fastutil
- disruptor
- snakeyaml
- hadoop-shaded-protobuf_3_25
- stream
- datasketches-java
- t-digest
- picocli
- tyrus-standalone-client
- jopt-simple
- ipaddress
- posix
- chronicle-core


Maven plugins that are not declared in `<properties>`, will be taken up in a subsequent PR:

- spotless-maven-plugin
- appassembler-maven-plugin
- jacoco-maven-plugin
- license-maven-plugin
- buildnumber-maven-plugin
- versions-maven-plugin
- maven-scm-provider-gitexe
- protobuf-maven-plugin
- javacc-maven-plugin
- scala-maven-plugin
- scalatest-maven-plugin
- frontend-maven-plugin
- checksum-maven-plugin
- exec-maven-plugin
- log4j-transform-maven-shade-plugin-extensions
- maven-jxr-plugin

Non-Maven plugins that are not declared in `<properties>`, will be taken up in a subsequent PR:
- javacc (not Maven)
- checkstyle (not Maven)