### PR TITLE
Adjusting `pinot_tests.yml` to enable manual testing on the fork repo

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -42,6 +42,7 @@ on:
       - "licenses/**"
       - "licenses-binary/**"
       - "**.md"
+  workflow_dispatch: {}
 
 jobs:
   linter-test:
@@ -78,7 +79,6 @@ jobs:
         run: .github/workflows/scripts/.pinot_linter.sh
 
   binary-compat-check:
-    if: github.repository == 'apache/pinot'
     runs-on: ubuntu-latest
     name: Pinot Binary Compatibility Check
     strategy:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -21,8 +21,7 @@ name: Pinot Tests
 
 on:
   push:
-    branches:
-      - master
+    branches: {}
     paths-ignore:
       - "contrib/**"
       - "docs/**"
@@ -32,8 +31,7 @@ on:
       - "licenses-binary/**"
       - "**.md"
   pull_request:
-    branches:
-      - master
+    branches: {}
     paths-ignore:
       - "contrib/**"
       - "docs/**"

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -21,7 +21,11 @@ name: Pinot Tests
 
 on:
   push:
-    branches: {}
+    branches:
+      - master
+      - manual-testing
+      - gha-spi-test
+      - gha-segment-spi-test
     paths-ignore:
       - "contrib/**"
       - "docs/**"
@@ -31,7 +35,11 @@ on:
       - "licenses-binary/**"
       - "**.md"
   pull_request:
-    branches: {}
+    branches:
+      - master
+      - manual-testing
+      - gha-spi-test
+      - gha-segment-spi-test
     paths-ignore:
       - "contrib/**"
       - "docs/**"

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout master into a subfolder
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: manual-testing
           path: master-head
       # Build the same module on master to produce the baseline JAR
       - name: Build SPI on master

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -23,9 +23,6 @@ on:
   push:
     branches:
       - master
-      - manual-testing
-      - gha-spi-test
-      - gha-segment-spi-test
     paths-ignore:
       - "contrib/**"
       - "docs/**"

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -268,10 +268,6 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "indexingConfigs");
   }
 
-  public String forTableGetServerInstances(String tableName) {
-    return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=server");
-  }
-
   public String forTableGetBrokerInstances(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=broker");
   }


### PR DESCRIPTION
Adjusting `pinot_tests.yml` to enable manual testing on the fork repo
Changes:
- Added `workflow_dispatch: {}`
- Removed `if: github.repository == 'apache/pinot'`