### PR TITLE
GHA japicmp CLI SPI Check – Test 1: Remove method in `pinot-spi`

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -268,10 +268,6 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "indexingConfigs");
   }
 
-  public String forTableGetServerInstances(String tableName) {
-    return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=server");
-  }
-
   public String forTableGetBrokerInstances(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=broker");
   }


### PR DESCRIPTION
This test removes a method from `pinot-spi/.../ControllerRequestURLBuilder.java` to verify that the japicmp CLI correctly detects binary incompatibility.