### PR TITLE
GHA japicmp CLI SPI Check – Test 2: Change the order of a method's parameters

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/NativeTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/NativeTextIndexReader.java
@@ -68,7 +68,7 @@ public class NativeTextIndexReader implements TextIndexReader {
 
   private File getTextIndexFile(File segmentIndexDir) {
     // will return null if file does not exist
-    File file = SegmentDirectoryPaths.findNativeTextIndexIndexFile(segmentIndexDir, _column);
+    File file = SegmentDirectoryPaths.findNativeTextIndexIndexFile(_column, segmentIndexDir);
     if (file == null) {
       throw new IllegalStateException("Failed to find text index file for column: " + _column);
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.data.Schema;
  */
 public class StatsCollectorConfig {
 
-  public final TableConfig _tableConfig;
+  private final TableConfig _tableConfig;
   private final Schema _schema;
   private final SegmentPartitionConfig _segmentPartitionConfig;
   private final Map<String, FieldConfig> _columnFieldConfigMap;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
@@ -35,7 +35,7 @@ import org.apache.pinot.spi.data.Schema;
  */
 public class StatsCollectorConfig {
 
-  private final TableConfig _tableConfig;
+  public final TableConfig _tableConfig;
   private final Schema _schema;
   private final SegmentPartitionConfig _segmentPartitionConfig;
   private final Map<String, FieldConfig> _columnFieldConfigMap;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectoryPaths.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectoryPaths.java
@@ -106,7 +106,7 @@ public class SegmentDirectoryPaths {
    * @return text index directory (if existst), null if index file does not exit
    */
   @Nullable
-  public static File findNativeTextIndexIndexFile(File indexDir, String column) {
+  public static File findNativeTextIndexIndexFile(String column, File indexDir) {
     String nativeIndexDirectory = column + V1Constants.Indexes.NATIVE_TEXT_INDEX_FILE_EXTENSION;
     return findFormatFile(indexDir, nativeIndexDirectory);
   }


### PR DESCRIPTION
This test changes the order of a method's parameters in `pinot-segment-spi/.../SegmentDirectoryPaths.java` to verify that the japicmp CLI correctly detects binary incompatibility.