### PR TITLE
GHA japicmp CLI SPI Check – Test 3-2: Change a variable from private to public (not an incompatible change)

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -32,7 +32,7 @@ import org.apache.pinot.spi.utils.StringUtil;
 
 
 public class ControllerRequestURLBuilder {
-  private final String _baseUrl;
+  public final String _baseUrl;
 
   private ControllerRequestURLBuilder(String baseUrl) {
     int length = baseUrl.length();


### PR DESCRIPTION
This PR changes a variable from `pinot-spi/.../ControllerRequestURLBuilder.java` from private to public. This is not an incompatible change and it's expected to exit 0.