### PR TITLE
Adjusting `pinot_tests.yml` to enable manual testing on the fork repo

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -34,6 +34,7 @@ on:
   pull_request:
     branches:
       - master
+      - new-manual-testing
     paths-ignore:
       - "contrib/**"
       - "docs/**"
@@ -42,6 +43,7 @@ on:
       - "licenses/**"
       - "licenses-binary/**"
       - "**.md"
+  workflow_dispatch: {}
 
 jobs:
   linter-test:
@@ -78,7 +80,6 @@ jobs:
         run: .github/workflows/scripts/.pinot_linter.sh
 
   binary-compat-check:
-    if: github.repository == 'apache/pinot'
     runs-on: ubuntu-latest
     name: Pinot Binary Compatibility Check
     steps:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -268,10 +268,6 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "indexingConfigs");
   }
 
-  public String forTableGetServerInstances(String tableName) {
-    return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=server");
-  }
-
   public String forTableGetBrokerInstances(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "instances?type=broker");
   }


### PR DESCRIPTION
Adjusting `pinot_tests.yml` to enable manual testing on the fork repo
Changes:
- Added `workflow_dispatch: {}`
- Removed `if: github.repository == 'apache/pinot'`